### PR TITLE
feat: Patch all `supportedLocalesOf` methods to report "is\*" as supp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - ... <!-- Add new lines here. -->
 - `@reykjavik/webtools/fixIcelandicLocale`:
+  - feat: Patch all `supportedLocalesOf` methods to report "is\*" as supported
   - fix: Use each `Intl.*` class' `supportedLocalesOf` method to map locales
 
 ## 0.1.28 – 0.1.29


### PR DESCRIPTION
This runs in opposition of our original thoughts:

```ts
// Static method (not patched since "is" is not ACTUALLY supported.)
```

But it somehow seems more reasonable to report "is*" AS supported because code might otherwise use a different language, for no reason.